### PR TITLE
Add Yahoo Finance closing price plotter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ dependencies = [
     "scikit-learn",
     "pydantic",
     "fastapi",
+    "yfinance",
+    "matplotlib",
 ]
 
 [build-system]

--- a/quantlab/data/__init__.py
+++ b/quantlab/data/__init__.py
@@ -1,0 +1,5 @@
+"""Data utilities for quantlab."""
+
+from .yahoo import plot_closing_price
+
+__all__ = ["plot_closing_price"]

--- a/quantlab/data/yahoo.py
+++ b/quantlab/data/yahoo.py
@@ -1,0 +1,32 @@
+"""Yahoo Finance data utilities."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import matplotlib.pyplot as plt
+import yfinance as yf
+
+
+def plot_closing_price(symbol: str, start: Optional[str] = None, end: Optional[str] = None) -> None:
+    """Fetch historical data for ``symbol`` from Yahoo Finance and plot the closing price.
+
+    Parameters
+    ----------
+    symbol:
+        The ticker symbol to download, e.g. ``"AAPL"``.
+    start:
+        Optional start date in ``YYYY-MM-DD`` format. If omitted, Yahoo Finance's
+        default is used.
+    end:
+        Optional end date in ``YYYY-MM-DD`` format. If omitted, the latest
+        available date is used.
+    """
+    data = yf.download(symbol, start=start, end=end)
+    if data.empty:
+        raise ValueError(f"No data returned for symbol {symbol}")
+
+    ax = data["Close"].plot(title=f"{symbol} Closing Price")
+    ax.set_ylabel("Price")
+    plt.tight_layout()
+    plt.show()


### PR DESCRIPTION
## Summary
- add Yahoo Finance helper to download and plot closing prices
- expose helper from data package
- include yfinance and matplotlib dependencies

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aff7b09fe083309a6d294a762ac682